### PR TITLE
Revert exception for 1st block

### DIFF
--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -42,7 +42,6 @@ import (
 //////////////////////////////////////////////////////////////////////////////
 const IMAGE_UPLOAD_MAX_CHUNK = 1024
 const IMAGE_UPLOAD_MIN_1ST_CHUNK = 32
-const IMAGE_UPLOAD_MAX_1ST_CHUNK = 512
 const IMAGE_UPLOAD_STATUS_MISSED = -1
 const IMAGE_UPLOAD_CHUNK_MISSED_WM = -1
 const IMAGE_UPLOAD_START_WS = 1
@@ -134,14 +133,8 @@ func findChunkLen(s sesn.Sesn, hash []byte, upgrade bool, data []byte,
 	off int, imageNum int, seq uint8) (int, error) {
 
 	// Let's start by encoding max allowed chunk len and we will see how many
-	// bytes we need to cut.
-	// First chunk needs to be header sized.
-	var chunklen int
-	if off == 0 {
-		chunklen = min(len(data), IMAGE_UPLOAD_MAX_1ST_CHUNK)
-	} else {
-		chunklen = min(len(data)-off, IMAGE_UPLOAD_MAX_CHUNK)
-	}
+	// bytes we need to cut
+	chunklen := min(len(data)-off, IMAGE_UPLOAD_MAX_CHUNK)
 
 	// Keep reducing the chunk size until the request fits the MTU.
 	for {


### PR DESCRIPTION
Revert previous commit and simply increase IMAGE_UPLOAD_MAX_CHUNK.
Client and server were misconfigured so no need for first block exception.